### PR TITLE
feat: bearer-token

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -274,6 +274,12 @@ export class BedrockChatModelProvider implements LanguageModelChatProvider {
 
 		if (method === "api-key") {
 			let apiKey = await this.secrets.get("bedrock.apiKey");
+			if (!apiKey) {
+				const envApiKey = process.env.AWS_BEARER_TOKEN_BEDROCK;
+				if (envApiKey && envApiKey.trim()) {
+					apiKey = envApiKey.trim();
+				}
+			}
 			if (!apiKey && !silent) {
 				const entered = await vscode.window.showInputBox({
 					title: "AWS Bedrock API Key",


### PR DESCRIPTION
Allow user to use bearer-token by default. Just needs to create a variable called AWS_BEARER_TOKEN_BEDROCK