### PR TITLE
Release 0.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "bedrock-vscode-chat",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bedrock-vscode-chat",
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"type": "git",
 		"url": "https://github.com/aristide1997/bedrock-vscode-chat"
 	},
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"engines": {
 		"vscode": "^1.108.0"
 	},


### PR DESCRIPTION
Patch release bundling:
- #9 omit `temperature` for Claude 4.x models (fixes Bedrock ValidationException)
- #8 optional proxy support (HTTP/1.1 via NodeHttpHandler when a proxy env var is set)

Version bump only on top of main; both fixes already merged. Verified: 23 unit/integration tests pass, e2e OVERALL PASS (incl. against the built 0.0.4 VSIX).