### PR TITLE
Add Bedrock model ID overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,17 @@
 						"type": "string",
 						"description": "AWS Session Token for temporary credentials (optional)",
 						"title": "Session Token"
+					},
+					"languageModelChatProvider.bedrock.modelOverrides": {
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						},
+						"description": "Map of model ID overrides. Use this to remap standard Bedrock model IDs to account-specific IDs (e.g., GovCloud or cross-region inference profiles). Keys are the model IDs shown in the VS Code chat dropdown; values are the actual Bedrock model IDs to use in API calls.",
+						"example": {
+							"anthropic.claude-sonnet-4-5-20250929-v1:0": "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+						},
+						"title": "Model ID Overrides"
 					}
 				}
 			},

--- a/src/providers/chat-request.handler.ts
+++ b/src/providers/chat-request.handler.ts
@@ -147,6 +147,14 @@ export class ChatRequestHandler {
 				requestInput.toolConfig = toolConfig as any;
 			}
 
+			// Resolve model ID through overrides (GovCloud, cross-region inference profiles)
+			const overrides = this.configService.getModelOverrides();
+			if (overrides && overrides[model.id] !== undefined) {
+				const resolvedId = overrides[model.id];
+				logger.log(`[Chat Request Handler] Model override: ${model.id} → ${resolvedId}`);
+				requestInput.modelId = resolvedId;
+			}
+
 			logger.log("[Chat Request Handler] Starting streaming request");
 			const credentials = this.authService.getCredentials(authConfig);
 			const stream = await this.bedrockClient.startConversationStream(credentials, requestInput);

--- a/src/services/configuration.service.ts
+++ b/src/services/configuration.service.ts
@@ -63,4 +63,16 @@ export class ConfigurationService {
 		const config = vscode.workspace.getConfiguration(this.configSection);
 		return config.get<string>('sessionToken');
 	}
+
+	/**
+	 * Get model ID overrides from configuration.
+	 * Returns a map of model ID -> override ID. Keys are standard model IDs
+	 * shown in the VS Code chat dropdown; values are the actual Bedrock model IDs
+	 * to use in API calls (e.g., GovCloud or cross-region inference profile IDs).
+	 * Returns undefined if no overrides are configured.
+	 */
+	getModelOverrides(): Record<string, string> | undefined {
+		const config = vscode.workspace.getConfiguration(this.configSection);
+		return config.get<Record<string, string>>('modelOverrides');
+	}
 }

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -8,6 +8,10 @@ import { convertTools } from "../converters/tools";
 import { validateRequest, validateTools } from "../validation";
 import { tryParseJSONObject } from "../converters/schema";
 import { ToolCallBufferManager } from "../tool-buffer";
+import { ChatRequestHandler } from "../providers/chat-request.handler";
+import { ModelService } from "../services/model.service";
+import { BedrockClient } from "../clients/bedrock.client";
+import { StreamProcessor } from "../stream-processor";
 
 suite("Bedrock Chat Provider Extension", () => {
 	suite("provider", () => {
@@ -260,6 +264,138 @@ suite("Bedrock Chat Provider Extension", () => {
 			buffer.appendArgs(2, '{"query":"different"}');
 			await buffer.tryEmit(2, progress);
 			assert.equal(emitted.length, 2);
+		});
+	});
+
+	suite("ChatRequestHandler model overrides", () => {
+		test("uses overridden model ID when override is present", async () => {
+			const modelId = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+			const overrideId = "us.anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+			const configService = {
+				getRegion: () => "us-east-1",
+				getModelOverrides: () => ({ [modelId]: overrideId }),
+			} as unknown as ConfigurationService;
+
+			const authConfig = { method: "apiKey" as const, apiKey: "fake-key" };
+			const authService = {
+				getAuthConfig: () => authConfig,
+				getCredentials: () => ({ accessKeyId: "fake", secretAccessKey: "fake", sessionToken: "fake" }),
+			} as unknown as AuthenticationService;
+
+			let capturedInput: any = null;
+			const bedrockClient = {
+				setRegion: () => {},
+				startConversationStream: async (creds: any, input: any) => {
+					capturedInput = input;
+					return { [Symbol.asyncIterator]: async function* () {} };
+				},
+			} as unknown as BedrockClient;
+
+			const streamProcessor = {
+				processStream: async () => {},
+			} as unknown as StreamProcessor;
+
+			const handler = new ChatRequestHandler(
+				{} as ModelService,
+				authService,
+				configService
+			);
+
+			// Replace private fields via any cast
+			(handler as any).bedrockClient = bedrockClient;
+			(handler as any).streamProcessor = streamProcessor;
+
+			const model: vscode.LanguageModelChatInformation = {
+				id: modelId,
+				name: "Claude",
+				family: "bedrock",
+				version: "1",
+				maxInputTokens: 100000,
+				maxOutputTokens: 4096,
+				capabilities: {},
+			} as any;
+
+			const messages: vscode.LanguageModelChatMessage[] = [
+				{ role: vscode.LanguageModelChatMessageRole.User, content: [new vscode.LanguageModelTextPart("hi")], name: undefined },
+			];
+
+			const tokenSource = new vscode.CancellationTokenSource();
+			await handler.handleChatRequest(
+				model,
+				messages,
+				{} as vscode.LanguageModelChatRequestHandleOptions,
+				{ report: () => {} },
+				tokenSource.token
+			);
+			tokenSource.dispose();
+
+			assert.ok(capturedInput !== null, "requestInput should have been captured");
+			assert.equal(capturedInput.modelId, overrideId, "modelId should be the overridden value");
+		});
+
+		test("falls back to default model ID when no override is present", async () => {
+			const modelId = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+			const configService = {
+				getRegion: () => "us-east-1",
+				getModelOverrides: () => ({ "some.other.model": "some.override" }),
+			} as unknown as ConfigurationService;
+
+			const authConfig = { method: "apiKey" as const, apiKey: "fake-key" };
+			const authService = {
+				getAuthConfig: () => authConfig,
+				getCredentials: () => ({ accessKeyId: "fake", secretAccessKey: "fake", sessionToken: "fake" }),
+			} as unknown as AuthenticationService;
+
+			let capturedInput: any = null;
+			const bedrockClient = {
+				setRegion: () => {},
+				startConversationStream: async (creds: any, input: any) => {
+					capturedInput = input;
+					return { [Symbol.asyncIterator]: async function* () {} };
+				},
+			} as unknown as BedrockClient;
+
+			const streamProcessor = {
+				processStream: async () => {},
+			} as unknown as StreamProcessor;
+
+			const handler = new ChatRequestHandler(
+				{} as ModelService,
+				authService,
+				configService
+			);
+
+			(handler as any).bedrockClient = bedrockClient;
+			(handler as any).streamProcessor = streamProcessor;
+
+			const model: vscode.LanguageModelChatInformation = {
+				id: modelId,
+				name: "Claude",
+				family: "bedrock",
+				version: "1",
+				maxInputTokens: 100000,
+				maxOutputTokens: 4096,
+				capabilities: {},
+			} as any;
+
+			const messages: vscode.LanguageModelChatMessage[] = [
+				{ role: vscode.LanguageModelChatMessageRole.User, content: [new vscode.LanguageModelTextPart("hi")], name: undefined },
+			];
+
+			const tokenSource = new vscode.CancellationTokenSource();
+			await handler.handleChatRequest(
+				model,
+				messages,
+				{} as vscode.LanguageModelChatRequestHandleOptions,
+				{ report: () => {} },
+				tokenSource.token
+			);
+			tokenSource.dispose();
+
+			assert.ok(capturedInput !== null, "requestInput should have been captured");
+			assert.equal(capturedInput.modelId, modelId, "modelId should fall back to the default model ID");
 		});
 	});
 });


### PR DESCRIPTION
This PR adds support for custom Bedrock model ID overrides via extension settings. I found this was required when using AWS bedrock on gov. It should also resolve issue #13.