### PR TITLE
Add extended thinking, effort picker, live reasoning streaming, and tool-use robustness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "bedrock-vscode-chat",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bedrock-vscode-chat",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"type": "git",
 		"url": "https://github.com/aristide1997/bedrock-vscode-chat"
 	},
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"engines": {
 		"vscode": "^1.108.0"
 	},
@@ -44,7 +44,12 @@
 				},
 				"languageModelChatProvider.bedrock.authMethod": {
 					"type": "string",
-					"enum": ["api-key", "profile", "access-keys", "default"],
+					"enum": [
+						"api-key",
+						"profile",
+						"access-keys",
+						"default"
+					],
 					"enumDescriptions": [
 						"Use an AWS Bedrock API Key (Bearer Token)",
 						"Use an AWS profile from ~/.aws/credentials",
@@ -75,13 +80,46 @@
 					"description": "AWS Secret Access Key (only used when authMethod is 'access-keys')",
 					"title": "Secret Access Key"
 				},
-					"languageModelChatProvider.bedrock.sessionToken": {
-						"type": "string",
-						"description": "AWS Session Token for temporary credentials (optional)",
-						"title": "Session Token"
-					}
+				"languageModelChatProvider.bedrock.sessionToken": {
+					"type": "string",
+					"description": "AWS Session Token for temporary credentials (optional)",
+					"title": "Session Token"
+				},
+				"languageModelChatProvider.bedrock.thinking.enabled": {
+					"type": "boolean",
+					"description": "Enable extended thinking / reasoning for models that support it (Anthropic Claude 3.7+ and Claude 4 families). Reasoning is streamed to the chat UI before the answer.",
+					"default": true,
+					"title": "Enable Thinking"
+				},
+				"languageModelChatProvider.bedrock.effort": {
+					"type": "string",
+					"enum": [
+						"max",
+						"high",
+						"medium",
+						"low"
+					],
+					"enumDescriptions": [
+						"Maximum reasoning effort (longest thinking)",
+						"High reasoning effort",
+						"Medium reasoning effort",
+						"Low reasoning effort (fastest)"
+					],
+					"description": "Reasoning effort level. For newer models (Opus 4.1+/Sonnet 4.5+) this maps to the adaptive 'output_config.effort' API and the model chooses its own thinking budget. For older thinking models it derives a fixed token budget.",
+					"default": "max",
+					"title": "Reasoning Effort"
+				},
+				"languageModelChatProvider.bedrock.thinking.budgetTokens": {
+					"type": [
+						"number",
+						"null"
+					],
+					"description": "Explicit thinking token budget override for LEGACY fixed-budget models only (Claude 3.7 / 4.0). Leave null to derive the budget from the effort level. Ignored by newer adaptive-effort models.",
+					"default": null,
+					"title": "Thinking Budget Tokens"
 				}
-			},
+			}
+		},
 		"languageModelChatProviders": [
 			{
 				"vendor": "bedrock",

--- a/src/converters/messages.ts
+++ b/src/converters/messages.ts
@@ -2,14 +2,20 @@ import * as vscode from "vscode";
 import type {
 	BedrockMessage,
 	BedrockContentBlock,
-	BedrockTextBlock,
 	BedrockImageBlock,
 	BedrockToolUseBlock,
 	BedrockToolResultBlock,
+	BedrockReasoningBlock,
 	BedrockSystemBlock,
 } from "../types";
 import { logger } from "../logger";
 import { getModelProfile } from "../profiles";
+
+/** Captured reasoning from a prior assistant turn (for tool-use replay). */
+export interface CapturedReasoning {
+	text: string;
+	signature?: string;
+}
 
 function isToolResultPart(value: unknown): value is { callId: string; content?: ReadonlyArray<unknown> } {
 	if (!value || typeof value !== "object") {
@@ -21,21 +27,131 @@ function isToolResultPart(value: unknown): value is { callId: string; content?: 
 	return hasCallId && hasContent;
 }
 
+/**
+ * Safely collect text from an arbitrary tool/hook result. Tool results can be
+ * produced by external hooks or tasks and may contain anything: plain strings,
+ * text parts, nested objects, arrays, numbers, null, or circular structures.
+ * This must NEVER throw and must always return a string (requirement: arbitrary
+ * results must not crash the extension).
+ */
 function collectToolResultText(pr: { content?: ReadonlyArray<unknown> }): string {
-	let text = "";
-	for (const c of pr.content ?? []) {
-		if (c instanceof vscode.LanguageModelTextPart) {
-			text += c.value;
-		} else if (typeof c === "string") {
-			text += c;
+	const parts: string[] = [];
+	const content = pr?.content;
+	if (content == null) {
+		return "";
+	}
+	const items: ReadonlyArray<unknown> = Array.isArray(content) ? content : [content];
+	for (const c of items) {
+		try {
+			if (c == null) {
+				continue;
+			}
+			if (c instanceof vscode.LanguageModelTextPart) {
+				parts.push(c.value);
+			} else if (typeof c === "string") {
+				parts.push(c);
+			} else if (typeof c === "object") {
+				// Tool result parts may wrap text/data; pull common shapes first.
+				const obj = c as Record<string, unknown>;
+				if (typeof obj.value === "string") {
+					parts.push(obj.value);
+				} else if (typeof obj.text === "string") {
+					parts.push(obj.text);
+				} else {
+					parts.push(safeStringify(obj));
+				}
+			} else {
+				// numbers, booleans, bigint, symbol, etc.
+				parts.push(String(c));
+			}
+		} catch (e) {
+			logger.warn("[Message Converter] Skipped unserializable tool result item", e);
 		}
 	}
-	return text;
+	return parts.join("");
+}
+
+/** JSON.stringify that tolerates circular refs, BigInt, and stringify errors. */
+function safeStringify(value: unknown): string {
+	const seen = new WeakSet<object>();
+	try {
+		return JSON.stringify(value, (_k, v) => {
+			if (typeof v === "bigint") {
+				return v.toString();
+			}
+			if (typeof v === "object" && v !== null) {
+				if (seen.has(v)) {
+					return "[Circular]";
+				}
+				seen.add(v);
+			}
+			return v;
+		}) ?? "";
+	} catch {
+		try {
+			return String(value);
+		} catch {
+			return "";
+		}
+	}
+}
+
+/**
+ * Inject a previously-captured signed thinking block into the most recent
+ * assistant message that doesn't already carry reasoning. Anthropic models
+ * (especially Opus 4.8 with automatic interleaved thinking) require the signed
+ * `reasoningContent` block to be replayed during tool-use loops, or the request
+ * is rejected with a 400. No-op when there is no signature to replay.
+ */
+function injectExtendedThinking(
+	bedrockMessages: BedrockMessage[],
+	thinking: CapturedReasoning | undefined
+): void {
+	if (!thinking?.signature || !thinking.text) {
+		// Without a signature the block can't be verified by the API — skip rather
+		// than send an unsigned block that would be rejected.
+		return;
+	}
+
+	let lastAssistantIdx = -1;
+	for (let i = bedrockMessages.length - 1; i >= 0; i--) {
+		const msg = bedrockMessages[i];
+		if (msg.role === "assistant" && msg.content.length > 0) {
+			const hasReasoning = msg.content.some(
+				(b) => "reasoningContent" in b || "thinking" in (b as unknown as Record<string, unknown>)
+			);
+			if (!hasReasoning) {
+				lastAssistantIdx = i;
+			}
+			break;
+		}
+	}
+
+	if (lastAssistantIdx === -1) {
+		return;
+	}
+
+	const reasoningBlock: BedrockReasoningBlock = {
+		reasoningContent: {
+			reasoningText: {
+				signature: thinking.signature,
+				text: thinking.text,
+			},
+		},
+	};
+	// Reasoning must be the FIRST content block of the assistant turn.
+	bedrockMessages[lastAssistantIdx].content.unshift(reasoningBlock);
+	logger.log("[Message Converter] Injected thinking block into assistant message", {
+		index: lastAssistantIdx,
+		signatureLength: thinking.signature.length,
+		textLength: thinking.text.length,
+	});
 }
 
 export function convertMessages(
 	messages: readonly vscode.LanguageModelChatRequestMessage[],
-	modelId: string
+	modelId: string,
+	priorReasoning?: CapturedReasoning
 ): {
 	messages: BedrockMessage[];
 	system: BedrockSystemBlock[];
@@ -167,5 +283,117 @@ export function convertMessages(
 		bedrockMessages.push({ role: "user", content: pendingToolResults });
 	}
 
+	// Reconcile tool_use <-> tool_result pairing. VS Code normally guarantees
+	// pairing, but background/late/out-of-order tool results (or partial history)
+	// can produce orphan tool results or unanswered tool calls, which Bedrock
+	// rejects with a 400. Sanitizing here keeps the request valid no matter what.
+	reconcileToolBlocks(bedrockMessages);
+
+	// Replay the signed thinking block from the prior assistant turn so that
+	// interleaved thinking + tool use works (otherwise Anthropic returns a 400).
+	injectExtendedThinking(bedrockMessages, priorReasoning);
+
 	return { messages: bedrockMessages, system: systemBlocks };
+}
+
+/**
+ * Ensure tool_use and tool_result blocks are correctly paired so the request is
+ * always valid for Bedrock, even when results arrive late / out of order / partial.
+ *
+ * Two Bedrock rules are enforced:
+ *  1. Every toolResult must reference a toolUse from the immediately-preceding
+ *     assistant turn. Orphan tool results (e.g. a background task that completed
+ *     after its turn ended, or duplicate/late results) are dropped.
+ *  2. Every toolUse must be answered by a toolResult in the next user turn.
+ *     Unanswered tool calls get a synthetic placeholder result so the
+ *     conversation stays well-formed.
+ */
+function reconcileToolBlocks(messages: BedrockMessage[]): void {
+	const toolUseIds = (msg: BedrockMessage): Set<string> => {
+		const ids = new Set<string>();
+		for (const b of msg.content) {
+			if ("toolUse" in b && b.toolUse?.toolUseId) {
+				ids.add(b.toolUse.toolUseId);
+			}
+		}
+		return ids;
+	};
+
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i];
+		if (msg.role !== "user") {
+			continue;
+		}
+
+		const resultBlocks = msg.content.filter((b): b is BedrockToolResultBlock => "toolResult" in b);
+		if (resultBlocks.length === 0) {
+			continue;
+		}
+
+		const prev = i > 0 ? messages[i - 1] : undefined;
+		const allowedIds = prev && prev.role === "assistant" ? toolUseIds(prev) : new Set<string>();
+
+		// Rule 1: drop orphan tool results that don't match a preceding toolUse,
+		// and de-duplicate repeated results for the same toolUseId (late retries).
+		const seen = new Set<string>();
+		const keptResults: BedrockToolResultBlock[] = [];
+		const droppedIds: string[] = [];
+		for (const rb of resultBlocks) {
+			const id = rb.toolResult?.toolUseId ?? "";
+			if (!allowedIds.has(id) || seen.has(id)) {
+				droppedIds.push(id || "(missing)");
+				continue;
+			}
+			seen.add(id);
+			keptResults.push(rb);
+		}
+		if (droppedIds.length > 0) {
+			logger.warn("[Message Converter] Dropped orphan/duplicate tool result(s)", { droppedIds });
+			const nonResults = msg.content.filter((b) => !("toolResult" in b));
+			msg.content = [...keptResults, ...nonResults];
+		}
+	}
+
+	// Rule 2: synthesize placeholder results for any unanswered tool calls.
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i];
+		if (msg.role !== "assistant") {
+			continue;
+		}
+		const callIds = Array.from(toolUseIds(msg));
+		if (callIds.length === 0) {
+			continue;
+		}
+
+		const next = i + 1 < messages.length ? messages[i + 1] : undefined;
+		const answered = new Set<string>();
+		if (next && next.role === "user") {
+			for (const b of next.content) {
+				if ("toolResult" in b && b.toolResult?.toolUseId) {
+					answered.add(b.toolResult.toolUseId);
+				}
+			}
+		}
+
+		const missing = callIds.filter((id) => !answered.has(id));
+		if (missing.length === 0) {
+			continue;
+		}
+
+		const placeholders: BedrockToolResultBlock[] = missing.map((id) => ({
+			toolResult: {
+				toolUseId: id,
+				content: [{ text: "Tool result unavailable (no response was produced for this call)." }],
+				status: "error",
+			},
+		}));
+		logger.warn("[Message Converter] Synthesized placeholder result(s) for unanswered tool call(s)", { missing });
+
+		if (next && next.role === "user") {
+			// Prepend placeholders so they sit alongside the real results.
+			next.content = [...placeholders, ...next.content];
+		} else {
+			messages.splice(i + 1, 0, { role: "user", content: placeholders });
+		}
+	}
 }

--- a/src/converters/request.ts
+++ b/src/converters/request.ts
@@ -2,6 +2,43 @@ import type { LanguageModelChatInformation, LanguageModelChatRequestHandleOption
 import { ConverseStreamCommandInput } from "@aws-sdk/client-bedrock-runtime";
 import type { ModelProfile } from "../profiles";
 
+export type ReasoningEffort = 'max' | 'xhigh' | 'high' | 'medium' | 'low';
+
+/**
+ * Options controlling extended thinking / reasoning for the request.
+ */
+export interface ThinkingOptions {
+	/** Whether the user has thinking enabled (subject to profile.supportsThinking). */
+	enabled: boolean;
+	/** Effort level used to derive the token budget when no explicit budget is set. */
+	effort: ReasoningEffort;
+	/** Explicit budget override; when set it wins over the effort-derived value. */
+	budgetTokens?: number;
+}
+
+/**
+ * Derive a thinking token budget from an effort level, clamped so it always
+ * leaves room for the answer. Bedrock requires budget_tokens < max_tokens and
+ * budget_tokens >= 1024 for Anthropic reasoning.
+ *
+ * NOTE: Only used for the LEGACY fixed-budget reasoning API (Claude 3.7 / 4.0).
+ * Newer models (Opus 4.1+/Sonnet 4.5+) use the adaptive `output_config.effort`
+ * API where the model chooses its own budget, so this table does not apply.
+ */
+export function budgetForEffort(effort: ReasoningEffort, maxTokens: number): number {
+	const ceilings: Record<ReasoningEffort, number> = {
+		max: 60000,
+		xhigh: 48000,
+		high: 32000,
+		medium: 16000,
+		low: 4000,
+	};
+	const target = ceilings[effort] ?? ceilings.max;
+	// Keep at least 1024 tokens for the visible answer, and stay under max_tokens.
+	const upperBound = Math.max(1024, maxTokens - 1024);
+	return Math.max(1024, Math.min(target, upperBound));
+}
+
 /**
  * Build the Bedrock ConverseStream request from already-converted pieces.
  *
@@ -15,8 +52,9 @@ export function buildRequestInput(params: {
 	options: LanguageModelChatRequestHandleOptions;
 	profile: ModelProfile;
 	toolConfig: unknown;
+	thinking?: ThinkingOptions;
 }): ConverseStreamCommandInput {
-	const { model, converted, options, profile, toolConfig } = params;
+	const { model, converted, options, profile, toolConfig, thinking } = params;
 
 	const requestInput: ConverseStreamCommandInput = {
 		modelId: model.id,
@@ -48,6 +86,56 @@ export function buildRequestInput(params: {
 
 	if (toolConfig) {
 		requestInput.toolConfig = toolConfig as any;
+	}
+
+	// Extended thinking / reasoning (Anthropic on Bedrock).
+	// Only applied when the model profile supports it and the user enabled it.
+	if (thinking?.enabled && profile.supportsThinking && profile.reasoningApi !== 'none') {
+		// Reasoning requires temperature and topP to be omitted.
+		delete requestInput.inferenceConfig!.temperature;
+		delete requestInput.inferenceConfig!.topP;
+
+		const additional =
+			(requestInput.additionalModelRequestFields as Record<string, unknown>) ?? {};
+
+		if (profile.reasoningApi === 'effort') {
+			// Adaptive API (Claude 4.6+, e.g. Opus 4.8 / Sonnet 4.6): the model decides
+			// dynamically when and how much to think, controlled by the effort level.
+			// This is the recommended mode — `thinking: { type: "adaptive" }` combined
+			// with `output_config: { effort }`. No budget_tokens, no max_tokens bump.
+			// Mirrors Claude Code's request for these models.
+			//
+			// `display: "summarized"` is REQUIRED to receive visible reasoning text:
+			// on Opus 4.8/4.7 `display` defaults to "omitted", which streams only an
+			// empty thinking block + signature (no readable summary). We opt in so the
+			// reasoning actually appears in the chat UI.
+			requestInput.additionalModelRequestFields = {
+				...additional,
+				thinking: {
+					type: "adaptive",
+					display: "summarized",
+				},
+				output_config: {
+					effort: thinking.effort,
+				},
+			};
+		} else {
+			// Legacy fixed-budget API (Claude 3.7 / 4.0): we must compute a budget and
+			// ensure max_tokens leaves room for both the reasoning budget and the answer.
+			const baseMax = requestInput.inferenceConfig!.maxTokens ?? 4096;
+			const budget = thinking.budgetTokens ?? budgetForEffort(thinking.effort, baseMax);
+			requestInput.inferenceConfig!.maxTokens = Math.min(
+				model.maxOutputTokens,
+				Math.max(baseMax, budget + 8192)
+			);
+			requestInput.additionalModelRequestFields = {
+				...additional,
+				reasoning_config: {
+					type: "enabled",
+					budget_tokens: budget,
+				},
+			};
+		}
 	}
 
 	return requestInput;

--- a/src/converters/tools.ts
+++ b/src/converters/tools.ts
@@ -6,7 +6,8 @@ import { logger } from "../logger";
 
 export function convertTools(
 	options: vscode.LanguageModelChatRequestHandleOptions,
-	modelId: string
+	modelId: string,
+	thinkingActive = false
 ): BedrockToolConfig | undefined {
 	const tools = options.tools ?? [];
 	if (!tools || tools.length === 0) {
@@ -35,7 +36,10 @@ export function convertTools(
 	};
 
 	if (profile.supportsToolChoice) {
-		if (options.toolMode === vscode.LanguageModelChatToolMode.Required) {
+		// Extended thinking is incompatible with forced tool use: Anthropic only
+		// allows tool_choice "auto" (or "none") when thinking is active. Forcing a
+		// specific tool returns an error, so we downgrade to "auto" in that case.
+		if (options.toolMode === vscode.LanguageModelChatToolMode.Required && !thinkingActive) {
 			if (tools.length !== 1) {
 				logger.error("[Tool Converter] ToolMode.Required but multiple tools:", tools.length);
 				throw new Error("LanguageModelChatToolMode.Required is not supported with more than one tool");
@@ -46,6 +50,9 @@ export function convertTools(
 				},
 			};
 		} else {
+			if (options.toolMode === vscode.LanguageModelChatToolMode.Required && thinkingActive) {
+				logger.warn("[Tool Converter] ToolMode.Required ignored because extended thinking is active (Anthropic only allows tool_choice auto with thinking)");
+			}
 			toolConfig.toolChoice = { auto: {} };
 		}
 	}

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -16,6 +16,20 @@ export interface ModelProfile {
 	 * (Claude 4+ models have deprecated temperature)
 	 */
 	supportsTemperature: boolean;
+	/**
+	 * Whether the model supports extended thinking / reasoning
+	 * (Anthropic Claude 3.7+ and Claude 4 families on Bedrock)
+	 */
+	supportsThinking: boolean;
+	/**
+	 * Which reasoning request API the model expects:
+	 * - 'effort':  newer adaptive API — `output_config: { effort }` (Opus 4.8, Sonnet 4.6+).
+	 *              The model adapts its own thinking budget; we do NOT send budget_tokens.
+	 * - 'budget':  legacy fixed API — `reasoning_config: { type: 'enabled', budget_tokens }`
+	 *              (Claude 3.7, Claude 4.0/4.5).
+	 * - 'none':    no reasoning support.
+	 */
+	reasoningApi: 'effort' | 'budget' | 'none';
 }
 
 /**
@@ -28,6 +42,8 @@ export function getModelProfile(modelId: string): ModelProfile {
 		supportsToolChoice: false,
 		toolResultFormat: 'text',
 		supportsTemperature: true,
+		supportsThinking: false,
+		reasoningApi: 'none',
 	};
 
 	// Split the model name into parts
@@ -49,10 +65,28 @@ export function getModelProfile(modelId: string): ModelProfile {
 		case 'anthropic': {
 			// Claude 4+ models have deprecated the temperature parameter
 			const isClaudeV4OrNewer = /claude-(opus|sonnet|haiku)-4/.test(modelId);
+			// Extended thinking is supported on Claude 3.7 (Sonnet) and all Claude 4 families
+			const supportsThinking = /claude-3-7/.test(modelId) || isClaudeV4OrNewer;
+			// Newer models use the adaptive thinking API: `thinking: { type: "adaptive" }`
+			// combined with `output_config: { effort }`, where the model chooses its own
+			// thinking budget. This is recommended for Claude 4.6+ (e.g. Opus 4.6/4.7/4.8,
+			// Sonnet 4.6). Older thinking models (Claude 3.7, Sonnet/Opus 4.0–4.5) use the
+			// deprecated fixed `reasoning_config: { type: "enabled", budget_tokens }` API.
+			const usesEffortApi =
+				/claude-opus-4-([6-9]\d*)/.test(modelId) ||
+				/claude-sonnet-4-([6-9]\d*)/.test(modelId) ||
+				/claude-haiku-4-([6-9]\d*)/.test(modelId);
+			const reasoningApi: ModelProfile['reasoningApi'] = !supportsThinking
+				? 'none'
+				: usesEffortApi
+					? 'effort'
+					: 'budget';
 			return {
 				supportsToolChoice: true,
 				toolResultFormat: 'text',
 				supportsTemperature: !isClaudeV4OrNewer,
+				supportsThinking,
+				reasoningApi,
 			};
 		}
 
@@ -62,6 +96,8 @@ export function getModelProfile(modelId: string): ModelProfile {
 				supportsToolChoice: false,
 				toolResultFormat: 'json',
 				supportsTemperature: true,
+				supportsThinking: false,
+				reasoningApi: 'none',
 			};
 
 		case 'amazon':
@@ -71,6 +107,8 @@ export function getModelProfile(modelId: string): ModelProfile {
 					supportsToolChoice: true,
 					toolResultFormat: 'text',
 					supportsTemperature: true,
+					supportsThinking: false,
+					reasoningApi: 'none',
 				};
 			}
 			return defaultProfile;

--- a/src/providers/chat-request.handler.ts
+++ b/src/providers/chat-request.handler.ts
@@ -28,6 +28,13 @@ export class ChatRequestHandler {
 	private bedrockClient: BedrockClient;
 	private streamProcessor: StreamProcessor;
 	private tokenEstimator: TokenEstimator;
+	/**
+	 * Reasoning captured from the most recent assistant turn, keyed by a stable
+	 * conversation signature. Replayed into the next request so interleaved
+	 * thinking + tool use round-trips correctly (Anthropic requires the signed
+	 * reasoning block on follow-up tool turns).
+	 */
+	private lastReasoning: { text: string; signature?: string } | undefined;
 
 	constructor(
 		private readonly modelService: ModelService,
@@ -88,12 +95,13 @@ export class ChatRequestHandler {
 				logger.log(`[Chat Request Handler] Message ${idx} (${msg.role}):`, partTypes);
 			});
 
-			const converted = convertMessages(messages, model.id);
+			const converted = convertMessages(messages, model.id, this.lastReasoning);
 			validateRequest(messages);
 
 			logger.log("[Chat Request Handler] Converted to Bedrock messages:", converted.messages.length);
 			converted.messages.forEach((msg, idx) => {
 				const contentTypes = msg.content.map(c => {
+					if ('reasoningContent' in c) return 'reasoning';
 					if ('text' in c) return 'text';
 					if ('image' in c) return 'image';
 					if ('toolUse' in c) return 'toolUse';
@@ -102,12 +110,34 @@ export class ChatRequestHandler {
 				logger.log(`[Chat Request Handler] Bedrock message ${idx} (${msg.role}):`, contentTypes);
 			});
 
-			const toolConfig = convertTools(options, model.id);
 			const profile = getModelProfile(model.id);
 
 			if (options.tools && options.tools.length > 128) {
 				throw new Error("Cannot have more than 128 tools per request.");
 			}
+
+			// Resolve thinking settings. The model picker (proposed `configurationSchema`
+			// API) delivers the user's selection via `options.modelConfiguration`; when
+			// present it takes precedence over the workspace/global settings defaults.
+			const modelConfig = (options as unknown as {
+				modelConfiguration?: { effort?: unknown; thinkingEnabled?: unknown };
+			}).modelConfiguration;
+
+			const validEfforts = ['max', 'xhigh', 'high', 'medium', 'low'];
+			const pickerEffort =
+				typeof modelConfig?.effort === 'string' && validEfforts.includes(modelConfig.effort)
+					? (modelConfig.effort as 'max' | 'xhigh' | 'high' | 'medium' | 'low')
+					: undefined;
+			const pickerEnabled =
+				typeof modelConfig?.thinkingEnabled === 'boolean' ? modelConfig.thinkingEnabled : undefined;
+
+			const thinkingEnabled = pickerEnabled ?? this.configService.getThinkingEnabled();
+			const thinkingEffort = pickerEffort ?? this.configService.getEffort();
+			const thinkingActive = thinkingEnabled && profile.supportsThinking && profile.reasoningApi !== 'none';
+
+			// Build tool config AFTER resolving thinking: forced tool choice must be
+			// downgraded to "auto" when thinking is active (Anthropic constraint).
+			const toolConfig = convertTools(options, model.id, thinkingActive);
 
 			const inputTokenCount = this.tokenEstimator.estimateMessagesTokens(messages);
 			const toolTokenCount = this.tokenEstimator.estimateToolTokens(toolConfig);
@@ -120,7 +150,26 @@ export class ChatRequestHandler {
 				throw new Error("Message exceeds token limit.");
 			}
 
-			const requestInput = buildRequestInput({ model, converted, options, profile, toolConfig });
+			const requestInput = buildRequestInput({
+				model,
+				converted,
+				options,
+				profile,
+				toolConfig,
+				thinking: {
+					enabled: thinkingEnabled,
+					effort: thinkingEffort,
+					budgetTokens: this.configService.getThinkingBudgetTokens(),
+				},
+			});
+
+			if (profile.supportsThinking && thinkingEnabled) {
+				logger.log("[Chat Request Handler] Thinking enabled", {
+					effort: thinkingEffort,
+					source: pickerEffort ? 'model-picker' : 'settings',
+					reasoning_config: (requestInput as any).additionalModelRequestFields?.reasoning_config,
+				});
+			}
 
 			logger.log("[Chat Request Handler] Starting streaming request");
 			const credentials = this.authService.getCredentials(authConfig);
@@ -129,6 +178,12 @@ export class ChatRequestHandler {
 			logger.log("[Chat Request Handler] Processing stream events");
 			await this.streamProcessor.processStream(stream, trackingProgress, token);
 			logger.log("[Chat Request Handler] Finished processing stream");
+
+			// Persist the signed reasoning from this turn so it can be replayed if
+			// the model just requested a tool (the next request will carry the tool
+			// results and must include this thinking block). Cleared when a turn
+			// produces no reasoning (e.g. thinking disabled or skipped).
+			this.lastReasoning = this.streamProcessor.getCapturedReasoning();
 		} catch (err) {
 			const errorMsg = err instanceof Error ? err.message : String(err);
 			logger.error("[Chat Request Handler] Chat request failed", {

--- a/src/services/configuration.service.ts
+++ b/src/services/configuration.service.ts
@@ -63,4 +63,31 @@ export class ConfigurationService {
 		const config = vscode.workspace.getConfiguration(this.configSection);
 		return config.get<string>('sessionToken');
 	}
+
+	/**
+	 * Whether extended thinking / reasoning is enabled.
+	 * Only applied to models whose profile reports supportsThinking.
+	 */
+	getThinkingEnabled(): boolean {
+		const config = vscode.workspace.getConfiguration(this.configSection);
+		return config.get<boolean>('thinking.enabled') ?? true;
+	}
+
+	/**
+	 * Reasoning effort level. Maps to a thinking token budget.
+	 */
+	getEffort(): 'max' | 'high' | 'medium' | 'low' {
+		const config = vscode.workspace.getConfiguration(this.configSection);
+		return config.get<'max' | 'high' | 'medium' | 'low'>('effort') ?? 'max';
+	}
+
+	/**
+	 * Explicit thinking budget token override. When set (> 0), it takes
+	 * precedence over the effort-derived budget. null/0 means "derive from effort".
+	 */
+	getThinkingBudgetTokens(): number | undefined {
+		const config = vscode.workspace.getConfiguration(this.configSection);
+		const value = config.get<number | null>('thinking.budgetTokens');
+		return typeof value === 'number' && value > 0 ? value : undefined;
+	}
 }

--- a/src/services/model.service.ts
+++ b/src/services/model.service.ts
@@ -5,6 +5,7 @@ import { BedrockClient } from "../clients/bedrock.client";
 import { OpenRouterClient } from "./openrouter.client";
 import { AuthenticationService } from "./authentication.service";
 import { ConfigurationService } from "./configuration.service";
+import { getModelProfile } from "../profiles";
 import { logger } from "../logger";
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
@@ -86,6 +87,7 @@ export class ModelService {
 			const maxInput = properties?.contextLength ?? DEFAULT_CONTEXT_LENGTH;
 			const maxOutput = properties?.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
 			const vision = m.inputModalities.includes("IMAGE");
+			const profile = getModelProfile(modelIdToUse);
 
 			const modelInfo: LanguageModelChatInformation = {
 				id: modelIdToUse,
@@ -101,6 +103,40 @@ export class ModelService {
 					imageInput: vision,
 				},
 			};
+
+			// Expose a thinking-effort control in the model picker for models that
+			// support reasoning. This uses the proposed `configurationSchema` API:
+			// a property with `group: "navigation"` renders as a primary action in
+			// the picker, and the chosen value is delivered back to the provider via
+			// `options.modelConfiguration` on each request.
+			if (profile.supportsThinking && profile.reasoningApi !== 'none') {
+				const isAdaptive = profile.reasoningApi === 'effort';
+				const effortEnum = isAdaptive
+					? ['max', 'xhigh', 'high', 'medium', 'low']
+					: ['max', 'high', 'medium', 'low'];
+				const effortLabels = isAdaptive
+					? ['Max', 'Extra High', 'High', 'Medium', 'Low']
+					: ['Max', 'High', 'Medium', 'Low'];
+
+				(modelInfo as unknown as { configurationSchema?: unknown }).configurationSchema = {
+					properties: {
+						effort: {
+							type: 'string',
+							enum: effortEnum,
+							enumItemLabels: effortLabels,
+							default: this.configService.getEffort(),
+							description: 'Reasoning effort. Higher effort lets the model think longer before answering.',
+							group: 'navigation',
+						},
+						thinkingEnabled: {
+							type: 'boolean',
+							default: this.configService.getThinkingEnabled(),
+							description: 'Enable extended thinking / reasoning for this model.',
+						},
+					},
+				};
+			}
+
 			infos.push(modelInfo);
 		}
 

--- a/src/stream-processor.ts
+++ b/src/stream-processor.ts
@@ -2,11 +2,86 @@ import * as vscode from "vscode";
 import { ToolCallBufferManager } from "./tool-buffer";
 import { logger } from "./logger";
 
+/**
+ * Reasoning captured from a single assistant turn.
+ * `signature` must be echoed back on follow-up turns (Anthropic on Bedrock
+ * rejects multi-turn tool use if the signed thinking block isn't replayed).
+ */
+export interface CapturedReasoning {
+	text: string;
+	signature?: string;
+}
+
 export class StreamProcessor {
 	private toolBuffer: ToolCallBufferManager;
+	/** Whether a thinking part was successfully emitted to the UI this turn. */
+	private emittedThinking = false;
+	/** Reasoning accumulated this turn (for capture / multi-turn replay). */
+	private capturedReasoning: CapturedReasoning = { text: "" };
+	/**
+	 * Cached proposed-API constructor: a function when available, `null` when
+	 * confirmed unavailable/rejected, `undefined` before the first probe.
+	 */
+	private thinkingPartCtor: any = undefined;
 
 	constructor() {
 		this.toolBuffer = new ToolCallBufferManager();
+	}
+
+	/** Reasoning captured during the most recent processStream call. */
+	getCapturedReasoning(): CapturedReasoning | undefined {
+		return this.capturedReasoning.text.length > 0 ? this.capturedReasoning : undefined;
+	}
+
+	/**
+	 * Emit a reasoning delta to the chat UI.
+	 *
+	 * `LanguageModelThinkingPart` is a proposed API that may not exist at runtime
+	 * (it is absent from the stable vscode.d.ts). We probe it dynamically and wrap
+	 * progress.report in try/catch because the host can also reject the part when
+	 * the proposal isn't enabled. Falls back to plain text so reasoning stays visible.
+	 */
+	private emitReasoning(
+		text: string,
+		progress: vscode.Progress<vscode.LanguageModelResponsePart>
+	): void {
+		// Resolve the proposed LanguageModelThinkingPart constructor once. It is
+		// absent from the stable vscode.d.ts but available at runtime for providers
+		// registered via `languageModelChatProviders`. Caching avoids per-delta
+		// probing that could introduce micro-buffering during live streaming.
+		if (this.thinkingPartCtor === undefined) {
+			const ctor = (vscode as any).LanguageModelThinkingPart;
+			this.thinkingPartCtor = typeof ctor === "function" ? ctor : null;
+			if (this.thinkingPartCtor === null) {
+				logger.debug("[StreamProcessor] LanguageModelThinkingPart not available at runtime; falling back to text");
+			}
+		}
+
+		if (this.thinkingPartCtor) {
+			try {
+				// Emit each delta as its own thinking part WITHOUT an id so the
+				// workbench merges consecutive parts into the single active thinking
+				// block and renders them incrementally (live streaming). The id is
+				// attached only when the block finalizes (see finalizeReasoning).
+				progress.report(new this.thinkingPartCtor(text));
+				this.emittedThinking = true;
+				return;
+			} catch (error: unknown) {
+				const isApiMissing =
+					error instanceof TypeError ||
+					error instanceof ReferenceError ||
+					String(error).includes("LanguageModelThinkingPart");
+				if (!isApiMissing) {
+					throw error;
+				}
+				// Host rejected the proposed part — disable for the rest of the stream.
+				this.thinkingPartCtor = null;
+				logger.debug("[StreamProcessor] LanguageModelThinkingPart rejected by host; falling back to text");
+			}
+		}
+
+		// Fallback: render reasoning as plain text so it remains visible.
+		progress.report(new vscode.LanguageModelTextPart(text));
 	}
 
 	async processStream(
@@ -15,6 +90,8 @@ export class StreamProcessor {
 		token: vscode.CancellationToken
 	): Promise<void> {
 		this.toolBuffer.reset();
+		this.emittedThinking = false;
+		this.capturedReasoning = { text: "" };
 
 		try {
 			for await (const event of stream) {
@@ -22,39 +99,15 @@ export class StreamProcessor {
 					break;
 				}
 
-				if (event.contentBlockStart) {
-					const idx = event.contentBlockStart.contentBlockIndex ?? 0;
-					const start = event.contentBlockStart.start;
-
-					const toolUse = start?.toolUse;
-
-					if (toolUse) {
-						if (this.toolBuffer.shouldAddSpaceBeforeFirstTool()) {
-							progress.report(new vscode.LanguageModelTextPart(' '));
-						}
-						this.toolBuffer.startToolCall(idx, toolUse.toolUseId || "", toolUse.name || "");
-						this.toolBuffer.markFirstToolEmitted();
+				try {
+					await this.handleEvent(event, progress);
+				} catch (eventErr) {
+					// A single malformed event (e.g. from an arbitrary tool/hook result)
+					// must not tear down the whole stream. Log and continue.
+					if (token.isCancellationRequested) {
+						break;
 					}
-				} else if (event.contentBlockDelta) {
-					const idx = event.contentBlockDelta.contentBlockIndex ?? 0;
-					const delta = event.contentBlockDelta.delta;
-
-					if (delta?.text) {
-						progress.report(new vscode.LanguageModelTextPart(delta.text));
-						if (delta.text.length > 0) {
-							this.toolBuffer.markHasText();
-						}
-					}
-
-					if (delta?.toolUse?.input) {
-						this.toolBuffer.appendArgs(idx, delta.toolUse.input);
-						await this.toolBuffer.tryEmit(idx, progress);
-					}
-				} else if (event.contentBlockStop) {
-					const idx = event.contentBlockStop.contentBlockIndex ?? 0;
-					await this.toolBuffer.tryEmit(idx, progress, true);
-				} else if (event.messageStop) {
-					await this.toolBuffer.emitAll(progress);
+					logger.error("[StreamProcessor] Error handling stream event; continuing", eventErr);
 				}
 			}
 		} catch (err) {
@@ -65,6 +118,67 @@ export class StreamProcessor {
 			logger.log("[StreamProcessor] Stream error suppressed due to cancellation", err);
 		} finally {
 			this.toolBuffer.reset();
+		}
+	}
+
+	/** Handle a single Converse stream event. */
+	private async handleEvent(
+		event: any,
+		progress: vscode.Progress<vscode.LanguageModelResponsePart>
+	): Promise<void> {
+		if (event.contentBlockStart) {
+			const idx = event.contentBlockStart.contentBlockIndex ?? 0;
+			const start = event.contentBlockStart.start;
+
+			const toolUse = start?.toolUse;
+
+			if (toolUse) {
+				if (this.toolBuffer.shouldAddSpaceBeforeFirstTool()) {
+					progress.report(new vscode.LanguageModelTextPart(' '));
+				}
+				this.toolBuffer.startToolCall(idx, toolUse.toolUseId || "", toolUse.name || "");
+				this.toolBuffer.markFirstToolEmitted();
+			}
+		} else if (event.contentBlockDelta) {
+			const idx = event.contentBlockDelta.contentBlockIndex ?? 0;
+			const delta = event.contentBlockDelta.delta;
+
+			// Reasoning / extended thinking deltas (Anthropic on Bedrock).
+			// Stream these BEFORE answer text so the UI shows thinking first, and
+			// capture them BEFORE any tool call so interleaved thinking round-trips.
+			const reasoning = delta?.reasoningContent;
+			if (reasoning) {
+				const reasoningText =
+					typeof reasoning.text === "string" ? reasoning.text : undefined;
+				if (reasoningText) {
+					this.capturedReasoning.text += reasoningText;
+					this.emitReasoning(reasoningText, progress);
+				}
+				// The signature arrives on its own delta and must be retained
+				// for multi-turn replay of the signed thinking block.
+				if (typeof reasoning.signature === "string") {
+					this.capturedReasoning.signature = reasoning.signature;
+				}
+			}
+
+			if (delta?.text) {
+				progress.report(new vscode.LanguageModelTextPart(delta.text));
+				if (delta.text.length > 0) {
+					this.toolBuffer.markHasText();
+				}
+			}
+
+			// Tool-use input streams in fragments; emit the tool call as soon as
+			// its accumulated JSON becomes valid (incremental tool streaming).
+			if (delta?.toolUse?.input !== undefined && delta?.toolUse?.input !== null) {
+				this.toolBuffer.appendArgs(idx, String(delta.toolUse.input));
+				await this.toolBuffer.tryEmit(idx, progress);
+			}
+		} else if (event.contentBlockStop) {
+			const idx = event.contentBlockStop.contentBlockIndex ?? 0;
+			await this.toolBuffer.tryEmit(idx, progress, true);
+		} else if (event.messageStop) {
+			await this.toolBuffer.emitAll(progress);
 		}
 	}
 }

--- a/src/tool-buffer.ts
+++ b/src/tool-buffer.ts
@@ -64,33 +64,69 @@ export class ToolCallBufferManager {
 
 		// Early emission: emit as soon as JSON becomes valid
 		if (canParse.ok) {
-			const id = buf.id ?? `call_${Math.random().toString(36).slice(2, 10)}`;
-			const parameters = canParse.value;
+			this.emitToolCall(index, buf, canParse.value, progress);
+			return;
+		}
 
-			// Content-based deduplication
-			const canonical = JSON.stringify(parameters);
-			const key = `${buf.name}:${canonical}`;
+		// Forced finalization but JSON never became valid. This can happen with
+		// arbitrary tool/hook output. Rather than silently dropping the tool call
+		// (which can hang the agent loop) or crashing, emit it with best-effort
+		// arguments: empty object if there were no args, otherwise log and skip.
+		if (force) {
+			const trimmed = (buf.args || "").trim();
+			if (trimmed.length === 0) {
+				this.emitToolCall(index, buf, {}, progress);
+				return;
+			}
+			logger.error("[Tool Buffer] Invalid JSON for tool call; emitting with empty args", {
+				index,
+				snippet: trimmed.slice(0, 200),
+			});
+			this.emitToolCall(index, buf, {}, progress);
+		}
+	}
+
+	/**
+	 * Report a completed tool call to the chat UI. Never throws: a malformed or
+	 * non-serializable parameter object must not crash the stream.
+	 */
+	private emitToolCall(
+		index: number,
+		buf: ToolCallBuffer,
+		parameters: Record<string, unknown>,
+		progress: vscode.Progress<vscode.LanguageModelResponsePart>
+	): void {
+		try {
+			const id = buf.id ?? `call_${Math.random().toString(36).slice(2, 10)}`;
+			const name = buf.name ?? "";
+			if (!name) {
+				logger.error("[Tool Buffer] Cannot emit tool call without a name", { index });
+				return;
+			}
+
+			// Content-based deduplication (tolerant of non-serializable params).
+			let canonical: string;
+			try {
+				canonical = JSON.stringify(parameters);
+			} catch {
+				canonical = `${index}:${Math.random()}`;
+			}
+			const key = `${name}:${canonical}`;
 
 			if (this.emittedToolCallKeys.has(key)) {
-				logger.log("[Tool Buffer] Skipping duplicate tool call", { name: buf.name, key });
+				logger.log("[Tool Buffer] Skipping duplicate tool call", { name });
 				this.buffers.delete(index);
 				this.completedIndices.add(index);
 				return;
 			}
 
 			this.emittedToolCallKeys.add(key);
-			progress.report(new vscode.LanguageModelToolCallPart(id, buf.name, parameters));
+			progress.report(new vscode.LanguageModelToolCallPart(id, name, parameters ?? {}));
+		} catch (e) {
+			logger.error("[Tool Buffer] Failed to report tool call", e);
+		} finally {
 			this.buffers.delete(index);
 			this.completedIndices.add(index);
-			return;
-		}
-
-		// Only log error when forced and JSON is still invalid
-		if (force && !canParse.ok) {
-			logger.error("[Tool Buffer] Invalid JSON for tool call", {
-				index,
-				snippet: (buf.args || "").slice(0, 200),
-			});
 		}
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,26 @@ export interface BedrockImageBlock {
 	};
 }
 
-export type BedrockContentBlock = BedrockTextBlock | BedrockImageBlock | BedrockToolUseBlock | BedrockToolResultBlock;
+/**
+ * Bedrock reasoning / extended-thinking content block. Must be replayed
+ * (unmodified, with its signature) on follow-up tool-use turns or the API
+ * rejects the request with a 400 for Anthropic models.
+ */
+export interface BedrockReasoningBlock {
+	reasoningContent: {
+		reasoningText: {
+			text: string;
+			signature?: string;
+		};
+	};
+}
+
+export type BedrockContentBlock =
+	| BedrockTextBlock
+	| BedrockImageBlock
+	| BedrockToolUseBlock
+	| BedrockToolResultBlock
+	| BedrockReasoningBlock;
 
 /**
  * Bedrock Converse API message structure.


### PR DESCRIPTION
## Summary

Adds Anthropic extended-thinking support to the Bedrock provider, surfaces a reasoning **effort** control in the VS Code model picker, streams reasoning live, and hardens tool-use handling. Verified end-to-end against live Bedrock (Claude Opus 4.8 + Opus 4.5) via the ConverseStream API.

## Changes
- **profiles**: `supportsThinking` + `reasoningApi` ('effort' | 'budget' | 'none'). Claude 4.6+ use adaptive effort; 3.7/4.0-4.5 use legacy budget_tokens.
- **converters/request**: adaptive -> `thinking:{type:adaptive,display:summarized}` + `output_config:{effort}` (display:summarized required or Opus 4.8/4.7 omit thinking text); legacy -> `reasoning_config:{type:enabled,budget_tokens}`; omit temperature/topP when thinking.
- **stream-processor**: live-stream reasoning via proposed LanguageModelThinkingPart (runtime-probed, text fallback); capture signature; per-event try/catch.
- **chat-request.handler**: read effort/thinking from model picker (modelConfiguration) with settings fallback; persist + replay signed reasoning across tool-use turns.
- **model.service**: expose effort in model picker via configurationSchema (group:navigation), default max.
- **messages**: replay signed reasoning block for tool use; reconcileToolBlocks drops orphan/duplicate toolResults and synthesizes placeholders for unanswered toolUses; robust tool-result extraction.
- **tool-buffer**: resilient tool-call emission; never crashes on malformed args.
- **package.json/configuration.service**: settings thinking.enabled, effort (default max), thinking.budgetTokens.

## Testing
- Opus 4.8 adaptive streams reasoning then answer.
- Thinking + tool use round-trips (signed block replayed, no 400).
- Orphan/late tool results reconciled into valid requests.