### PR TITLE
feat: inference profile overrides support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ Configure the extension through VS Code settings (Cmd/Ctrl + , then search for "
 - **Profile**: AWS profile name (when using profile method)
 - **Access Key ID / Secret Access Key**: AWS credentials (when using access-keys method)
 - **Session Token**: AWS Session Token for temporary credentials (optional, used with access-keys method)
+- **Inference Profile Overrides**: Map model IDs to [application inference profile](https://docs.aws.amazon.com/bedrock/latest/userguide/application-inference-profiles.html) ARNs or IDs. Use this to route specific models through your own application inference profiles instead of the default system profiles.
+
+#### Setting up Inference Profile Overrides
+
+Application inference profiles let you define custom throughput, routing, and tagging for Bedrock invocations. To route a model through your own profile:
+
+1. [Create an application inference profile](https://docs.aws.amazon.com/bedrock/latest/userguide/application-inference-profiles-create.html) in the AWS Console.
+2. Open VS Code Settings (`Ctrl/Cmd + ,`), search for **Bedrock**, and locate **Inference Profile Overrides**.
+3. Click **Edit in settings.json** and add a mapping:
+
+```json
+"languageModelChatProvider.bedrock.inferenceProfileOverrides": {
+    "anthropic.claude-opus-4-8-20250514": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
+    "anthropic.claude-sonnet-4-6": "arn:aws:bedrock:ap-southeast-2:123456789012:application-inference-profile/def456"
+}
+```
+
+You can use either the full ARN or just the profile ID (e.g., `"abc123"`) — both are accepted.
+
+**Note**: When an override is set, the model still appears under its bare ID in the model picker and capability detection still works against the base model. The override substitution happens only at invocation time.
 
 ### Commands
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,12 @@
 				},
 				"languageModelChatProvider.bedrock.authMethod": {
 					"type": "string",
-					"enum": ["api-key", "profile", "access-keys", "default"],
+					"enum": [
+						"api-key",
+						"profile",
+						"access-keys",
+						"default"
+					],
 					"enumDescriptions": [
 						"Use an AWS Bedrock API Key (Bearer Token)",
 						"Use an AWS profile from ~/.aws/credentials",
@@ -75,13 +80,22 @@
 					"description": "AWS Secret Access Key (only used when authMethod is 'access-keys')",
 					"title": "Secret Access Key"
 				},
-					"languageModelChatProvider.bedrock.sessionToken": {
-						"type": "string",
-						"description": "AWS Session Token for temporary credentials (optional)",
-						"title": "Session Token"
+				"languageModelChatProvider.bedrock.sessionToken": {
+					"type": "string",
+					"description": "AWS Session Token for temporary credentials (optional)",
+					"title": "Session Token"
+				},
+				"languageModelChatProvider.bedrock.inferenceProfileOverrides": {
+					"type": "object",
+					"description": "Map of model IDs to inference profile ARNs or IDs. Use this to route specific models through application inference profiles. Example: { \"anthropic.claude-sonnet-4-6\": \"arn:aws:bedrock:ap-southeast-2:123456789012:application-inference-profile/abc123\" }",
+					"title": "Inference Profile Overrides",
+					"default": {},
+					"additionalProperties": {
+						"type": "string"
 					}
 				}
-			},
+			}
+		},
 		"languageModelChatProviders": [
 			{
 				"vendor": "bedrock",

--- a/src/providers/chat-request.handler.ts
+++ b/src/providers/chat-request.handler.ts
@@ -122,6 +122,14 @@ export class ChatRequestHandler {
 
 			const requestInput = buildRequestInput({ model, converted, options, profile, toolConfig });
 
+			// Substitute invocation target (override ARN or system profile) at the wire level.
+			// This keeps the bare model ID for getModelProfile() so capability detection
+			// (e.g. temperature suppression for Claude 4+) still works correctly.
+			const invocationTarget = this.modelService.getInvocationTarget(model.id);
+			if (invocationTarget) {
+				requestInput.modelId = invocationTarget;
+			}
+
 			logger.log("[Chat Request Handler] Starting streaming request");
 			const credentials = this.authService.getCredentials(authConfig);
 			const stream = await this.bedrockClient.startConversationStream(credentials, requestInput);

--- a/src/services/configuration.service.ts
+++ b/src/services/configuration.service.ts
@@ -63,4 +63,14 @@ export class ConfigurationService {
 		const config = vscode.workspace.getConfiguration(this.configSection);
 		return config.get<string>('sessionToken');
 	}
+
+	/**
+	 * Get user-provided inference profile overrides.
+	 * Maps bare model IDs (e.g. "anthropic.claude-sonnet-4-6") to
+	 * full inference profile ARNs or IDs to use at invocation time.
+	 */
+	getInferenceProfileOverrides(): Record<string, string> {
+		const config = vscode.workspace.getConfiguration(this.configSection);
+		return config.get<Record<string, string>>('inferenceProfileOverrides') ?? {};
+	}
 }

--- a/src/services/model.service.ts
+++ b/src/services/model.service.ts
@@ -18,6 +18,12 @@ export class ModelService {
 	private bedrockClient: BedrockClient;
 	private openRouterClient: OpenRouterClient;
 	private chatEndpoints: { model: string; modelMaxPromptTokens: number }[] = [];
+	/**
+	 * Maps a bare model ID to the actual target to use at invocation time.
+	 * This is either a user-provided override ARN or a system inference profile ID.
+	 * The public model ID stays bare so capability detection (getModelProfile) still works.
+	 */
+	private invocationTargets = new Map<string, string>();
 
 	constructor(
 		private readonly authService: AuthenticationService,
@@ -70,25 +76,41 @@ export class ModelService {
 		}
 
 		const infos: LanguageModelChatInformation[] = [];
-		const regionPrefix = region.split("-")[0];
+		const regionGeo = region.startsWith("ap-") ? "apac" : region.split("-")[0];
+		const overrides = this.configService.getInferenceProfileOverrides();
+		this.invocationTargets.clear();
 
 		for (const m of models) {
 			if (!m.responseStreamingSupported || !m.outputModalities.includes("TEXT")) {
 				continue;
 			}
 
-			const inferenceProfileId = `${regionPrefix}.${m.modelId}`;
-			const hasInferenceProfile = availableProfileIds.has(inferenceProfileId);
-			const modelIdToUse = hasInferenceProfile ? inferenceProfileId : m.modelId;
+			// Resolution order: user override → system inference profile → bare ID
+			const overrideTarget = overrides[m.modelId];
+			if (overrideTarget) {
+				this.invocationTargets.set(m.modelId, overrideTarget);
+			} else {
+				const candidates = [...availableProfileIds].filter((pid) => pid.endsWith(`.${m.modelId}`));
+				const matchingProfileId =
+					candidates.find((pid) => pid.startsWith(`${regionGeo}.`)) ??
+					candidates.find((pid) => pid.startsWith("au.")) ??
+					candidates.find((pid) => pid.startsWith("global.")) ??
+					candidates[0];
+				if (matchingProfileId) {
+					this.invocationTargets.set(m.modelId, matchingProfileId);
+				}
+			}
+
+			const hasInferenceProfile = this.invocationTargets.has(m.modelId);
 
 			// Try to get model properties from OpenRouter, fall back to defaults
-			const properties = await this.openRouterClient.getModelProperties(modelIdToUse);
+			const properties = await this.openRouterClient.getModelProperties(m.modelId);
 			const maxInput = properties?.contextLength ?? DEFAULT_CONTEXT_LENGTH;
 			const maxOutput = properties?.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
 			const vision = m.inputModalities.includes("IMAGE");
 
 			const modelInfo: LanguageModelChatInformation = {
-				id: modelIdToUse,
+				id: m.modelId,
 				name: m.modelName,
 				tooltip: `AWS Bedrock - ${m.providerName}${hasInferenceProfile ? ' (Cross-Region)' : ''}`,
 				detail: `${m.providerName} • ${hasInferenceProfile ? 'Multi-Region' : region}`,
@@ -117,5 +139,13 @@ export class ModelService {
 	 */
 	getChatEndpoints(): { model: string; modelMaxPromptTokens: number }[] {
 		return this.chatEndpoints;
+	}
+
+	/**
+	 * Get the invocation target (override ARN or system profile ID) for a bare model ID.
+	 * Returns undefined if the model should be invoked with its bare ID directly.
+	 */
+	getInvocationTarget(bareModelId: string): string | undefined {
+		return this.invocationTargets.get(bareModelId);
 	}
 }


### PR DESCRIPTION
Adds support for AWS Bedrock [application inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/application-inference-profiles.html), letting users route model invocations through custom application inference profiles of their choice.

### What changed

- **New VS Code setting** `bedrock.inferenceProfileOverrides` — a string→string map from bare model IDs to user-provided inference profile ARNs or IDs (e.g., `{ "anthropic.claude-opus-4-8-20250514": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123" }`).

- **Resolution order** for invocation targets (applied at request time):
  1. **User override** from `inferenceProfileOverrides`
  2. **System inference profile** (cross-region, auto-matched per model)
  3. **Bare model ID** (direct invocation, fallback)

- **Bare model IDs preserved** in the model picker and capability detection — the override substitution happens only at the wire-invocation level, so features like `getModelProfile()` (e.g. temperature suppression for Claude 4+) continue to work correctly.

- **Region prefix matching** improved to handle `ap-*` regions under the `apac` geo prefix instead of using just the region's first segment.
