### PR TITLE
Fix image format mismatch error by detecting actual format from magic bytes

### DIFF
--- a/src/clients/bedrock.client.ts
+++ b/src/clients/bedrock.client.ts
@@ -117,19 +117,82 @@ export class BedrockClient {
 		credentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity> | undefined,
 		input: ConverseStreamCommandInput
 	): Promise<AsyncIterable<any>> {
-		const client = new BedrockRuntimeClient({
-			region: this.region,
-			credentials,
-			...proxyRequestHandler(),
-		});
+		try {
+			const client = new BedrockRuntimeClient({
+				region: this.region,
+				credentials,
+				...proxyRequestHandler(),
+			});
 
-		const command = new ConverseStreamCommand(input);
-		const response = await client.send(command);
+			const command = new ConverseStreamCommand(input);
+			const response = await client.send(command);
 
-		if (!response.stream) {
-			throw new Error("No stream in response");
+			if (!response.stream) {
+				throw new Error("No stream in response");
+			}
+
+			return response.stream;
+		} catch (err) {
+			// Enhanced error handling to prevent "unknown" errors in ToolCallingLoop
+			const errorMessage = this.formatAwsError(err);
+			logger.error("[Bedrock Client] Failed to start conversation stream", {
+				error: errorMessage,
+				modelId: input.modelId,
+			});
+			throw new Error(errorMessage);
+		}
+	}
+
+	/**
+	 * Format AWS SDK errors into readable messages
+	 */
+	private formatAwsError(err: unknown): string {
+		if (!err) {
+			return "Unknown error occurred";
 		}
 
-		return response.stream;
+		// Handle AWS SDK errors
+		if (typeof err === 'object' && err !== null) {
+			const awsError = err as any;
+			
+			// AWS SDK v3 error structure
+			if (awsError.$metadata) {
+				const parts: string[] = [];
+				
+				if (awsError.name) {
+					parts.push(awsError.name);
+				}
+				
+				if (awsError.message) {
+					parts.push(awsError.message);
+				}
+				
+				if (awsError.$metadata.httpStatusCode) {
+					parts.push(`(HTTP ${awsError.$metadata.httpStatusCode})`);
+				}
+				
+				if (parts.length > 0) {
+					return parts.join(': ');
+				}
+			}
+			
+			// Generic Error object
+			if (err instanceof Error) {
+				return err.message || err.name || "Error without message";
+			}
+			
+			// Object with message property
+			if ('message' in err && typeof err.message === 'string') {
+				return err.message;
+			}
+		}
+
+		// Fallback to string conversion
+		try {
+			const str = String(err);
+			return str !== '[object Object]' ? str : "Unknown error (object without message)";
+		} catch {
+			return "Unknown error (cannot convert to string)";
+		}
 	}
 }

--- a/src/converters/messages.ts
+++ b/src/converters/messages.ts
@@ -64,21 +64,55 @@ export function convertMessages(
 			} else if (typeof part === 'object' && part !== null && 'mimeType' in part && 'data' in part) {
 				const dataPart = part as { mimeType: string; data: Uint8Array };
 				if (dataPart.mimeType.startsWith('image/')) {
-					const mimeTypeParts = dataPart.mimeType.split('/');
-					const format = mimeTypeParts[1]?.toLowerCase();
+					// Detect actual image format from magic bytes to handle cases where
+					// the reported mimeType doesn't match the actual image data
+					let actualFormat: string | null = null;
+					const bytes = dataPart.data;
+					
+					if (bytes instanceof Uint8Array && bytes.length >= 12) {
+						// PNG: 89 50 4E 47
+						if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4E && bytes[3] === 0x47) {
+							actualFormat = 'png';
+						}
+						// JPEG: FF D8 FF
+						else if (bytes[0] === 0xFF && bytes[1] === 0xD8 && bytes[2] === 0xFF) {
+							actualFormat = 'jpeg';
+						}
+						// GIF: 47 49 46 38
+						else if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38) {
+							actualFormat = 'gif';
+						}
+						// WebP: RIFF ... WEBP
+						else if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+								 bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50) {
+							actualFormat = 'webp';
+						}
+					}
+					
+					// Fall back to mimeType if detection fails
+					if (!actualFormat) {
+						const mimeTypeParts = dataPart.mimeType.split('/');
+						actualFormat = mimeTypeParts[1]?.toLowerCase();
+						// Normalize jpg to jpeg
+						if (actualFormat === 'jpg') {
+							actualFormat = 'jpeg';
+						}
+					}
+					
+					logger.log(`[Message Converter] Image detected - mimeType: ${dataPart.mimeType}, actual format: ${actualFormat}`);
 
-					if (format === 'png' || format === 'jpeg' || format === 'gif' || format === 'webp') {
+					if (actualFormat === 'png' || actualFormat === 'jpeg' || actualFormat === 'gif' || actualFormat === 'webp') {
 						imageBlocks.push({
 							image: {
-								format: format as "png" | "jpeg" | "gif" | "webp",
+								format: actualFormat as "png" | "jpeg" | "gif" | "webp",
 								source: {
 									bytes: dataPart.data,
 								},
 							},
 						});
-						logger.log(`[Message Converter] Added image block with format: ${format}`);
+						logger.log(`[Message Converter] Added image block with format: ${actualFormat}`);
 					} else {
-						logger.warn(`[Message Converter] Unsupported image format: ${format}`);
+						logger.warn(`[Message Converter] Unsupported image format: ${actualFormat}`);
 					}
 				}
 			} else if (part instanceof vscode.LanguageModelToolCallPart) {

--- a/src/stream-processor.ts
+++ b/src/stream-processor.ts
@@ -60,7 +60,27 @@ export class StreamProcessor {
 		} catch (err) {
 			// Suppress errors when cancellation was requested, since it is expected in that case.
 			if (!token.isCancellationRequested) {
-				throw err;
+				// Ensure error has a message to prevent "unknown" errors in ToolCallingLoop
+				if (err instanceof Error) {
+					logger.error("[StreamProcessor] Stream processing failed", {
+						name: err.name,
+						message: err.message,
+						stack: err.stack,
+					});
+					throw err;
+				}
+				
+				// Handle non-Error objects
+				const errorMessage = typeof err === 'object' && err !== null && 'message' in err
+					? String((err as any).message)
+					: String(err);
+				
+				logger.error("[StreamProcessor] Stream processing failed with non-Error", {
+					error: errorMessage,
+					type: typeof err,
+				});
+				
+				throw new Error(`Stream processing failed: ${errorMessage || 'unknown error'}`);
 			}
 			logger.log("[StreamProcessor] Stream error suppressed due to cancellation", err);
 		} finally {


### PR DESCRIPTION
## Problem

When attaching images from VS Code's integrated browser, the extension throws a ValidationException:

```
ValidationException: The model returned the following errors: messages.0.content.2.image.source.bytes: 
The image was specified using the image/jpeg media type, but the image appears to be a image/png image
```

This happens because VS Code's browser attachment can report incorrect MIME types for images (e.g., reporting `image/jpeg` when the actual data is PNG format), causing AWS Bedrock API to reject the request.

## Solution

This PR implements magic byte detection to identify the actual image format from the binary data instead of blindly trusting the reported mimeType. The fix:

1. **Detects actual format using magic bytes**:
   - PNG: `89 50 4E 47`
   - JPEG: `FF D8 FF`
   - GIF: `47 49 46 38`
   - WebP: `52 49 46 46 ... 57 45 42 50`

2. **Falls back to mimeType** if magic byte detection fails

3. **Normalizes** `jpg` to `jpeg` for consistency

4. **Logs** both the declared mimeType and detected format for debugging

## Testing

Tested with images attached from VS Code's integrated browser that previously caused the ValidationException. The extension now correctly detects and uses the actual image format regardless of the reported MIME type.

## Impact

This fix allows users to successfully attach images from the VS Code browser without encountering format mismatch errors, improving the overall user experience when using vision-capable models.